### PR TITLE
[#66][REFACTOR] 로그인 시 반환하는 응답 정보에 id 추가

### DIFF
--- a/src/main/java/com/plog/domain/member/dto/AuthInfoRes.java
+++ b/src/main/java/com/plog/domain/member/dto/AuthInfoRes.java
@@ -15,11 +15,13 @@ import lombok.Builder;
 
 @Builder
 public record AuthInfoRes(
+        Long id,
         String nickname,
         String accessToken
 ) {
     public static AuthInfoRes from(AuthLoginResult res) {
         return AuthInfoRes.builder()
+                .id(res.id())
                 .nickname(res.nickname())
                 .accessToken(res.accessToken())
                 .build();

--- a/src/main/java/com/plog/domain/member/dto/AuthLoginResult.java
+++ b/src/main/java/com/plog/domain/member/dto/AuthLoginResult.java
@@ -14,6 +14,7 @@ import lombok.Builder;
  */
 @Builder
 public record AuthLoginResult(
+        Long id,
         String nickname,
         String accessToken,
         String refreshToken

--- a/src/main/java/com/plog/global/security/LoginFilter.java
+++ b/src/main/java/com/plog/global/security/LoginFilter.java
@@ -111,6 +111,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.setContentType("application/json;charset=UTF-8");
         AuthInfoRes authInfoRes = AuthInfoRes.builder()
+                .id(user.getId())
                 .nickname(user.getNickname())
                 .accessToken(accessToken)
                 .build();

--- a/src/test/java/com/plog/global/security/LoginFilterTest.java
+++ b/src/test/java/com/plog/global/security/LoginFilterTest.java
@@ -53,7 +53,7 @@ class LoginFilterTest {
     @Mock private AuthenticationManager authenticationManager;
     @Mock
     private JwtUtils jwtUtils;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
     @Spy
     private TokenResolver tokenResolver = new TokenResolver(3600000, "localhost", false);
 
@@ -110,6 +110,7 @@ class LoginFilterTest {
         assertThat(response.getCookie("refreshToken").isHttpOnly()).isTrue();
 
         String content = response.getContentAsString();
+        assertThat(content).contains("\"id\":1");
         assertThat(content).contains("plogger님 환영합니다.");
         assertThat(content).contains("mock-access-token");
     }


### PR DESCRIPTION
<!-- PR의 제목은 "[#이슈번호] [종류(ex.FEATURE)] 이슈이름" 으로 작성 -->

<!-- Auto close 할 이슈 번호 -->
- close #66 

## ✨ 구현 기능 명세

<!-- 해당 이슈에서 구현한 기능을 간단하게 작성 -->
- 로그인 시 클라이언트 편의성을 위하여 id를 추가로 반환합니다.
- DTO 수정과 로그인 필터에서 해당 DTO를 이용해 값을 설정하는 로직이 짧게 추가되었습니다.